### PR TITLE
Use percentage heights to avoid vh mobile height issue

### DIFF
--- a/fresh.css
+++ b/fresh.css
@@ -1,11 +1,17 @@
+.root {
+  height: 100%;
+}
+
 .cuerpo {
   margin: 0;
   font-family: sans-serif;
+  height: 100%;
 }
 
 .stack {
   margin: 0;
   padding: 0;
+  height: 100%;
 }
 
 .flavor {

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="tape-clean tape-white">
+<html lang="en-US" class="root tape-clean tape-white">
 <meta charset="utf-8">
 
 <title>your element balance</title>

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ $(function() {
       $(this)
         .css("font-size", value*0.62 + "vh")
         .closest(".flavor")
-        .css("height", value + "vh")
+        .css("height", value + "%")
         .css("font-size", value*0.38 + "vh")
     })
   }


### PR DESCRIPTION
`vh` is causing excess height in mobile safari and chrome